### PR TITLE
Avoid permanently switching to foreground window keyboard layout on Windows

### DIFF
--- a/src/keyboard_win.cc
+++ b/src/keyboard_win.cc
@@ -261,17 +261,28 @@ const char* _VKeyToStr(int vkey) {
   return "VK_UNKNOWN";
 }
 
-void _EnsureForegroundKBLayout() {
-  DWORD dwThreadId = 0;
-  HWND hWnd = GetForegroundWindow();
-  if (hWnd != NULL) {
-    dwThreadId = GetWindowThreadProcessId(hWnd, NULL);
+class UseForegroundKeyboardLayoutScope {
+  UseForegroundKeyboardLayoutScope() : original_layout(GetKeyboardLayout(0)) {
+    if (auto window = GetForegroundWindow()) {
+      const auto thread_id = GetWindowThreadProcessId(window, nullptr);
+      ActivateKeyboardLayout(GetKeyboardLayout(thread_id), 0);
+    }
   }
-  ActivateKeyboardLayout(GetKeyboardLayout(dwThreadId), 0);
-}
+
+  ~UseForegroundKeyboardLayoutScope() {
+    ActivateKeyboardLayout(original_layout, 0);
+  }
+
+  UseForegroundKeyboardLayoutScope(const UseForegroundKeyboardLayoutScope&) = delete;
+  UseForegroundKeyboardLayoutScope& operator=(const UseForegroundKeyboardLayoutScope&) =
+      delete;
+
+private:
+  HKL original_layout = nullptr;
+};
 
 napi_value _GetKeyMap(napi_env env, napi_callback_info info) {
-  _EnsureForegroundKBLayout();
+  UseForegroundKeyboardLayoutScope use_foreground_keyboard_layout;
 
   napi_value result;
   NAPI_CALL(env, napi_create_object(env, &result));
@@ -334,7 +345,7 @@ std::string GetStringRegKey(std::string path, std::string name) {
 }
 
 napi_value _GetCurrentKeyboardLayout(napi_env env, napi_callback_info info) {
-  _EnsureForegroundKBLayout();
+  UseForegroundKeyboardLayoutScope use_foreground_keyboard_layout;
 
   char chr_layout_name[KL_NAMELENGTH];
   if (!GetKeyboardLayoutName(chr_layout_name)) {


### PR DESCRIPTION
In e1ee48fa20, we started switching to the foreground window keyboard
layout when using some of the APIs. This was done to ensure that we'd
get the main process keyboard layout (which is what Electron windows
would use) even when the APIs are called in the render process.

This works fine if the foreground app is the same as the caller of these
APIs, but if the foreground app is something else, we are inadvertently
switching to its keyboard layout. This can happen e.g. if some Electron app
calls these APIs while it's in the background.

This goes against Windows principles — the user may choose to use
different layouts in different apps.

Ideally we should remove this code and recommend that these APIs are
only used in the main process, but for now, we can avoid breaking
changes by simply switching back to the original layout after the
relevant keyboard querying code has executed.